### PR TITLE
Fixes the crash on real iOS Devices

### DIFF
--- a/IOS.Libraries/Properties/AssemblyInfo.cs
+++ b/IOS.Libraries/Properties/AssemblyInfo.cs
@@ -33,5 +33,3 @@ using ObjCRuntime;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
-
-[assembly: LinkWith ("Webtrekk.a", LinkTarget.Arm64 | LinkTarget.ArmV6 | LinkTarget.ArmV7 | LinkTarget.ArmV7s | LinkTarget.Simulator, ForceLoad = true, IsCxx = true)]

--- a/IOS.Libraries/Properties/AssemblyInfo.cs
+++ b/IOS.Libraries/Properties/AssemblyInfo.cs
@@ -6,7 +6,6 @@ using Foundation;
 // This attribute allows you to mark your assemblies as “safe to link”.
 // When the attribute is present, the linker—if enabled—will process the assembly
 // even if you’re using the “Link SDK assemblies only” option, which is the default for device builds.
-using ObjCRuntime;
 
 [assembly: LinkerSafe]
 

--- a/IOS.Libraries/Properties/AssemblyInfo.cs
+++ b/IOS.Libraries/Properties/AssemblyInfo.cs
@@ -6,6 +6,7 @@ using Foundation;
 // This attribute allows you to mark your assemblies as “safe to link”.
 // When the attribute is present, the linker—if enabled—will process the assembly
 // even if you’re using the “Link SDK assemblies only” option, which is the default for device builds.
+using ObjCRuntime;
 
 [assembly: LinkerSafe]
 
@@ -32,3 +33,5 @@ using Foundation;
 
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
+
+[assembly: LinkWith ("Webtrekk.a", LinkTarget.Arm64 | LinkTarget.ArmV6 | LinkTarget.ArmV7 | LinkTarget.ArmV7s | LinkTarget.Simulator, ForceLoad = true, IsCxx = true)]

--- a/IOS.Libraries/Webtrekk.linkwith.cs
+++ b/IOS.Libraries/Webtrekk.linkwith.cs
@@ -1,4 +1,4 @@
 using ObjCRuntime;
 using Foundation;
 
-[assembly: LinkWith ("Webtrekk.a", SmartLink = true, ForceLoad = true)]
+[assembly: LinkWith ("Webtrekk.a", LinkTarget.Arm64 | LinkTarget.ArmV6 | LinkTarget.ArmV7 | LinkTarget.ArmV7s | LinkTarget.Simulator, ForceLoad = true, IsCxx = true)]


### PR DESCRIPTION
The WebTrekk iOS library used a category method called:
+[NSMutableDictionary wtDictionaryWithDictionary:andObject:forKey:]

The Webtrekk Archive File needs to be explictly linked into
IOS.Libraries assembly, and it needs to have the "-force_load"
tag set to true because:

"You might be wondering, why do you need "force_load" command, and the
reason is that the -ObjC flag although it compiles the code in, it does
not preserve the metadata required to support categories (the
linker/compiler dead code elimination strips it) which you need at
runtime for Xamarin.iOS."

From:
https://developer.xamarin.com/guides/ios/advanced_topics/binding_objective-c/binding_objc_libs/#Linking_the_Dependencies

See Also:
http://stackoverflow.com/questions/2567498/objective-c-categories-in-static-library
